### PR TITLE
Prevent a crash when a node being compared has no attributes

### DIFF
--- a/LexicographicalComparer.cs
+++ b/LexicographicalComparer.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace sortxml
+{
+    /*
+     * Basic LexicographicalComparer lifted from https://stackoverflow.com/a/7205788/11569
+     * 
+     */
+    class LexicographicalComparer : IComparer<String>
+    {
+
+        static readonly Int32 NORM_IGNORECASE = 0x00000001;
+        static readonly Int32 NORM_IGNORENONSPACE = 0x00000002;
+        static readonly Int32 NORM_IGNORESYMBOLS = 0x00000004;
+        static readonly Int32 LINGUISTIC_IGNORECASE = 0x00000010;
+        static readonly Int32 LINGUISTIC_IGNOREDIACRITIC = 0x00000020;
+        static readonly Int32 NORM_IGNOREKANATYPE = 0x00010000;
+        static readonly Int32 NORM_IGNOREWIDTH = 0x00020000;
+        static readonly Int32 NORM_LINGUISTIC_CASING = 0x08000000;
+        static readonly Int32 SORT_STRINGSORT = 0x00001000;
+        static readonly Int32 SORT_DIGITSASNUMBERS = 0x00000008;
+
+        static readonly String LOCALE_NAME_USER_DEFAULT = null;
+        static readonly String LOCALE_NAME_INVARIANT = String.Empty;
+        static readonly String LOCALE_NAME_SYSTEM_DEFAULT = "!sys-default-locale";
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        static extern Int32 CompareStringEx(
+          String localeName,
+          Int32 flags,
+          String str1,
+          Int32 count1,
+          String str2,
+          Int32 count2,
+          IntPtr versionInformation,
+          IntPtr reserved,
+          Int32 param
+        );
+
+
+        readonly String locale;
+
+        public LexicographicalComparer() : this(CultureInfo.CurrentCulture) { }
+
+        public LexicographicalComparer(CultureInfo cultureInfo)
+        {
+            if (cultureInfo.IsNeutralCulture)
+                this.locale = LOCALE_NAME_INVARIANT;
+            else
+                this.locale = cultureInfo.Name;
+        }
+
+        public Int32 Compare(String x, String y)
+        {
+            // CompareStringEx return 1, 2, or 3. Subtract 2 to get the return value.
+            return CompareStringEx(
+              this.locale,
+              SORT_DIGITSASNUMBERS, // Add other flags if required.
+              x,
+              x.Length,
+              y,
+              y.Length,
+              IntPtr.Zero,
+              IntPtr.Zero,
+              0) - 2;
+        }
+        public static Int32 Compare(String x, String y,  System.StringComparison options)
+        {
+            Int32 flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT;
+            string locale = CultureInfo.CurrentCulture.Name;
+            switch (options)
+            {
+                case StringComparison.CurrentCulture:
+                    locale = CultureInfo.CurrentCulture.Name;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT;
+                    break;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    locale = CultureInfo.CurrentCulture.Name;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT | LINGUISTIC_IGNORECASE;
+                    break;
+                case StringComparison.InvariantCulture:
+                    locale = LOCALE_NAME_INVARIANT;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT;
+                    break;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    locale = LOCALE_NAME_INVARIANT;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT | LINGUISTIC_IGNORECASE;
+                    break;
+                case StringComparison.Ordinal:
+                    locale = CultureInfo.CurrentCulture.Name;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT;
+                    break;
+                case StringComparison.OrdinalIgnoreCase:
+                    locale = CultureInfo.CurrentCulture.Name;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT | NORM_IGNORECASE;
+                    break;
+                default:
+                    locale = CultureInfo.CurrentCulture.Name;
+                    flags = SORT_DIGITSASNUMBERS | SORT_STRINGSORT;
+                    break;
+            }
+            // CompareStringEx return 1, 2, or 3. Subtract 2 to get the return value.
+            return CompareStringEx(
+              locale,
+              flags, // Add other flags if required.
+              x,
+              x.Length,
+              y,
+              y.Length,
+              IntPtr.Zero,
+              IntPtr.Zero,
+              0) - 2;
+        }
+    }
+    }

--- a/Program.cs
+++ b/Program.cs
@@ -193,6 +193,15 @@ namespace sortxml
             //       (Sorting attributes is done before node sorting happens,
             //       if specified).
             if (result == 0) {
+                if (a.Attributes == null && b.Attributes == null) {
+                    return 0;
+                } else if (a.Attributes == null)
+                {
+                    return 1;
+                } else if (b.Attributes == null)
+                {
+                    return -1;
+                }
                 col1 = (a.Attributes.Count >= b.Attributes.Count) ? a.Attributes : b.Attributes;
                 col2 = (a.Attributes.Count >= b.Attributes.Count) ? b.Attributes : a.Attributes;
 

--- a/Program.cs
+++ b/Program.cs
@@ -37,7 +37,8 @@ namespace sortxml
             sort_attr = true,
             pretty = true,
             pause = false,
-            overwriteSelf = false;
+            overwriteSelf = false,
+            sort_logical = true;
         static StringComparison
             sort_node_comp = StringComparison.CurrentCulture, // Default to case-sensitive sorting.
             sort_attr_comp = StringComparison.CurrentCulture;
@@ -79,6 +80,10 @@ namespace sortxml
                     } else if (al.Equals("!s") || al.Equals("!sort") || al.StartsWith("!sortall") || al.StartsWith("!sort-all")) {
                         sort_node = false;
                         sort_attr = false;
+                    } else if (al.Equals("l") || al.StartsWith("numbers-l") || al.StartsWith("numbersl")) {
+                        sort_logical = true;
+                    } else if (al.Equals("!l") || al.StartsWith("numbers-s") || al.StartsWith("numberss")) {
+                        sort_logical = false;
                     } else if (al.StartsWith("sortn") || al.StartsWith("sort-n")) {
                         sort_node = true;
                     } else if (al.StartsWith("!sortn") || al.StartsWith("!sort-n")) {
@@ -180,13 +185,22 @@ namespace sortxml
             }
         }
 
+        static int StringCompare(string a, string b, StringComparison comparisonType)
+        {
+            if (sort_logical) {
+                return LexicographicalComparer.Compare(a, b, comparisonType);
+            } else {
+                return String.Compare(a, b, comparisonType);
+            }
+        }
+
         static int SortDelegate( XmlNode a, XmlNode b )
         {
             XmlAttribute aa, bb;
             XmlAttributeCollection col1, col2;
             int result;
 
-            result = string.Compare(a.Name, b.Name, sort_node_comp);
+            result = StringCompare(a.Name, b.Name, sort_node_comp);
 
             // NOTE: Always sort the _nodes_ based on its attributes (when the 
             //       name matches), but don't actually sort the node's attributes.
@@ -209,9 +223,9 @@ namespace sortxml
                     if (i < col2.Count) {
                         aa = col1[i];
                         bb = col2[i];
-                        result = string.Compare(aa.Name, bb.Name, sort_attr_comp);
+                        result = StringCompare(aa.Name, bb.Name, sort_attr_comp);
                         if (result == 0) {
-                            result = string.Compare(aa.Value, bb.Value, sort_attr_comp);
+                            result = StringCompare(aa.Value, bb.Value, sort_attr_comp);
                             if (result != 0) {
                                 return result;
                             }
@@ -271,9 +285,9 @@ namespace sortxml
 
             attrs.Sort(delegate( XmlAttribute a, XmlAttribute b )
             {
-                result = string.Compare(a.Name, b.Name, sort_attr_comp);
+                result = StringCompare(a.Name, b.Name, sort_attr_comp);
                 if (result == 0) {
-                    return string.Compare(a.Value, b.Value, sort_attr_comp);
+                    return StringCompare(a.Value, b.Value, sort_attr_comp);
                 } else if (primary_attr.Length > 0) {
                     // If a primary_attr is specified, it is always made the first attribute!
                     if (a.Name.Equals(primary_attr, sort_attr_comp)) {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Copyright 2014 Kody Brown (@wasatchwizard)
                     Sorts node and attributes case-sensitively.
                     If neither option is specified, uses case-sensitive sort.
 
+      /l --numbers-logical
+                    abc2 comes before abc10.
+      !l --numbers-string
+                    abc2 comes after abc10.
+                    If neither option is specified, uses numbers-logical sort.
+
       --overwrite   Writes back to the infile.
                     Only used if outfile is not specified.
 

--- a/sortxml.csproj
+++ b/sortxml.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LexicographicalComparer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Something with no attributes is deemed "less than" as something with attributes